### PR TITLE
Set python version to a version line

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.2
+python-3.5.x


### PR DESCRIPTION
Current buildpacks no longer support 3.5.2